### PR TITLE
Fix compile error due to rename

### DIFF
--- a/components/hv5222/__init__.py
+++ b/components/hv5222/__init__.py
@@ -55,7 +55,7 @@ HV5222_PIN_SCHEMA = pins.gpio_base_schema(
     cv.int_range(min=0, max=128),
     modes=[CONF_OUTPUT],
     mode_validator=_validate_output_mode,
-    invertable=True,
+    invertible=True,
 ).extend(
     {
         cv.Required(CONF_HV5222): cv.use_id(HV5222component),


### PR DESCRIPTION
Fix compiler error on newest esphome, see: https://github.com/esphome/esphome/commit/a59e1c7011142e3d44b11efe688e9685f6b29eae